### PR TITLE
update thumbnail url

### DIFF
--- a/lichess-slack-app-daily-puzzle/lambda_function.py
+++ b/lichess-slack-app-daily-puzzle/lambda_function.py
@@ -19,7 +19,7 @@ def lambda_handler(event, context):
     c = r.content
     o = json.loads(c)
     url = "https://lichess.org/training/" + str(o['puzzle']['id'])
-    imgurl = "https://lichess.org/training/export/png/" + str(o['puzzle']['id']) + ".png"
+    imgurl = "https://lichess1.org/training/export/gif/thumbnail/" + str(o['puzzle']['id']) + ".gif"
     
     # Broadcast
     config = Config(

--- a/lichess-slack-app-slash-command/lambda_function.py
+++ b/lichess-slack-app-slash-command/lambda_function.py
@@ -55,7 +55,7 @@ def lambda_handler(event, context):
     r = requests.get('https://lichess.org/training/daily', headers={'Accept': 'application/vnd.lichess.v5+json'})
     o = json.loads(r.content)
     url = "https://lichess.org/training/" + str(o['puzzle']['id'])
-    imgurl = "https://lichess.org/training/export/png/" + str(o['puzzle']['id']) + ".png"
+    imgurl = "https://lichess1.org/training/export/gif/thumbnail/" + str(o['puzzle']['id']) + ".gif"
     response = {
        "response_type": "in_channel",
        "text": url,


### PR DESCRIPTION
* Save a redirect (thumbnails are now generated by the same service that produces GIF animations, and the old PNG url just redirects to that).
* Hit the CDN instead of lichess itself.

Untested.